### PR TITLE
feature/add sensors to simulation

### DIFF
--- a/bolt_description/urdf/bolt.urdf.xacro
+++ b/bolt_description/urdf/bolt.urdf.xacro
@@ -13,7 +13,8 @@
   <xacro:include filename="leg.xacro"/>
   <xacro:include filename="sensor.xacro"/>
   <xacro:body />
-  <xacro:sensor />
+  <xacro:sensor
+    link_name="imu_link"/>
   <xacro:leg
     prefix="FL"
     is_front="true"

--- a/bolt_description/urdf/bolt.urdf.xacro
+++ b/bolt_description/urdf/bolt.urdf.xacro
@@ -11,7 +11,9 @@
   <link name="base_link"/>
   <xacro:include filename="body.xacro"/>
   <xacro:include filename="leg.xacro"/>
+  <xacro:include filename="sensor.xacro"/>
   <xacro:body />
+  <xacro:sensor />
   <xacro:leg
     prefix="FL"
     is_front="true"

--- a/bolt_description/urdf/sensor.xacro
+++ b/bolt_description/urdf/sensor.xacro
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" name="bolt">
+  <xacro:macro name="sensor">
+    <joint name="sensor_joint" type="fixed">
+      <parent link="base_link"/>
+      <child link="sensor_link"/>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <axis xyz="0 0 1"/>
+    </joint>
+    <link name="sensor_link">
+      <inertial>
+        <origin xyz="0 0 0" rpy="0 0 0" />
+        <mass value="0.0"/>
+        <inertia ixx="0.0" ixy="0.0" ixz="0.0"
+          iyy="0.0" iyz="0.0"
+          izz="0.0"
+          />
+      </inertial>
+    </link>
+  </xacro:macro>
+</robot>
+

--- a/bolt_description/urdf/sensor.xacro
+++ b/bolt_description/urdf/sensor.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://playerstage.sourceforge.net/gazebo/xmlschema/#interface" name="bolt">
-  <xacro:macro name="sensor">
-    <joint name="sensor_joint" type="fixed">
+  <xacro:macro name="sensor" params="link_name">
+    <joint name="${link_name}_joint" type="fixed">
       <parent link="base_link"/>
-      <child link="sensor_link"/>
+      <child link="${link_name}"/>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <axis xyz="0 0 1"/>
     </joint>
-    <link name="sensor_link">
+    <link name="${link_name}">
       <inertial>
         <origin xyz="0 0 0" rpy="0 0 0" />
         <mass value="0.0"/>

--- a/bolt_mujoco_simulation/CMakeLists.txt
+++ b/bolt_mujoco_simulation/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(ament_cmake REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
 
 find_package(PkgConfig REQUIRED)
 pkg_search_module(GLFW REQUIRED glfw3)
@@ -82,6 +83,7 @@ target_include_directories(mujoco_simulator PUBLIC
 
 ament_target_dependencies(mujoco_simulator PUBLIC
   rclcpp
+  sensor_msgs
 )
 
 # X11 OpenGL: link with libmujoco210.so, libglew.so, libGL.so

--- a/bolt_mujoco_simulation/etc/robot.xml
+++ b/bolt_mujoco_simulation/etc/robot.xml
@@ -2,6 +2,9 @@
   <body name="robot" pos="0 0 0">
     <geom name="body_visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.8 0.8 0.8 1" mesh="bolt_body"/>
     <geom name="body_collision" type="mesh" rgba="0.8 0.8 0.8 1" mesh="bolt_body"/>
+    <body name="sensor_body" pos="0 0 0">
+      <site name="sensor_site" type="box" size="0.05 0.05 0.05" rgba="0.5 0.5 0.5 1"/>
+    </body>
     <body name="FL_SHOULDER" pos="0 0.0636 0">
       <inertial pos="0.0170826 -0.00446892 -0.0109583" quat="0.380445 0.573263 0.68117 0.250275" mass="0.140043" diaginertia="0.000140999 0.000103321 5.85997e-05"/>
       <joint name="FL_HAA" pos="0 0 0" axis="1 0 0" limited="true" range="-3.14 3.14" actuatorfrcrange="-100 100"/>

--- a/bolt_mujoco_simulation/etc/robot.xml
+++ b/bolt_mujoco_simulation/etc/robot.xml
@@ -2,7 +2,7 @@
   <body name="robot" pos="0 0 0">
     <geom name="body_visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.8 0.8 0.8 1" mesh="bolt_body"/>
     <geom name="body_collision" type="mesh" rgba="0.8 0.8 0.8 1" mesh="bolt_body"/>
-    <body name="sensor_body" pos="0 0 0">
+    <body name="sensor_link" pos="0 0 0">
       <site name="sensor_site" type="box" size="0.05 0.05 0.05" rgba="0.5 0.5 0.5 1"/>
     </body>
     <body name="FL_SHOULDER" pos="0 0.0636 0">

--- a/bolt_mujoco_simulation/etc/robot.xml
+++ b/bolt_mujoco_simulation/etc/robot.xml
@@ -2,8 +2,8 @@
   <body name="robot" pos="0 0 0">
     <geom name="body_visual" type="mesh" contype="0" conaffinity="0" group="1" density="0" rgba="0.8 0.8 0.8 1" mesh="bolt_body"/>
     <geom name="body_collision" type="mesh" rgba="0.8 0.8 0.8 1" mesh="bolt_body"/>
-    <body name="sensor_link" pos="0 0 0">
-      <site name="sensor_site" type="box" size="0.05 0.05 0.05" rgba="0.5 0.5 0.5 1"/>
+    <body name="imu_link" pos="0 0 0">
+      <site name="imu_site" type="box" size="0.05 0.05 0.05" rgba="0.5 0.5 0.5 1"/>
     </body>
     <body name="FL_SHOULDER" pos="0 0.0636 0">
       <inertial pos="0.0170826 -0.00446892 -0.0109583" quat="0.380445 0.573263 0.68117 0.250275" mass="0.140043" diaginertia="0.000140999 0.000103321 5.85997e-05"/>

--- a/bolt_mujoco_simulation/etc/sensors.xml
+++ b/bolt_mujoco_simulation/etc/sensors.xml
@@ -1,7 +1,7 @@
 <include>
   <sensor>
-    <gyro name="gyro_sensor" site="sensor_site"/>
-    <accelerometer name="accel_sensor" site="sensor_site"/>
-    <framequat name="orient_sensor" objtype="site" objname="sensor_site"/>
+    <gyro name="gyro_sensor" site="imu_site"/>
+    <accelerometer name="accel_sensor" site="imu_site"/>
+    <framequat name="orient_sensor" objtype="site" objname="imu_site"/>
   </sensor>
 </include>

--- a/bolt_mujoco_simulation/etc/sensors.xml
+++ b/bolt_mujoco_simulation/etc/sensors.xml
@@ -1,0 +1,7 @@
+<include>
+  <sensor>
+    <gyro name="gyro_sensor" site="sensor_site"/>
+    <accelerometer name="accel_sensor" site="sensor_site"/>
+    <framequat name="orient_sensor" objtype="site" objname="sensor_site"/>
+  </sensor>
+</include>

--- a/bolt_mujoco_simulation/etc/world_fixed.xml
+++ b/bolt_mujoco_simulation/etc/world_fixed.xml
@@ -20,4 +20,5 @@
       " />
   </keyframe>
   <include file="contacts.xml"/>
+  <include file="sensors.xml"/>
 </mujoco>

--- a/bolt_mujoco_simulation/etc/world_pole_constrained.xml
+++ b/bolt_mujoco_simulation/etc/world_pole_constrained.xml
@@ -21,4 +21,5 @@
       " />
   </keyframe>
   <include file="contacts.xml"/>
+  <include file="sensors.xml"/>
 </mujoco>

--- a/bolt_mujoco_simulation/etc/world_sagittal_constrained.xml
+++ b/bolt_mujoco_simulation/etc/world_sagittal_constrained.xml
@@ -23,4 +23,5 @@
       " />
   </keyframe>
   <include file="contacts.xml"/>
+  <include file="sensors.xml"/>
 </mujoco>

--- a/bolt_mujoco_simulation/etc/world_unconstrained.xml
+++ b/bolt_mujoco_simulation/etc/world_unconstrained.xml
@@ -15,7 +15,7 @@
     <key name="initial_joint_positions" time="0"
       qpos="0.0 0.0 0.5 0.0 0.0 0.0 0.0
       0.0
-      0.5
+      1.0
       -1.0
       0.0
       0.5
@@ -23,4 +23,5 @@
       " />
   </keyframe>
   <include file="contacts.xml"/>
+  <include file="sensors.xml"/>
 </mujoco>

--- a/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
+++ b/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
@@ -19,6 +19,11 @@ class MuJoCoSimulator {
   MuJoCoSimulator();
   void syncStates();
 
+  // Sensor IDs and similar
+  int sensor_orient_id;
+  int sensor_angular_vel_id;
+  int sensor_linear_acc_id;
+
  public:
   // Modern singleton approach
   MuJoCoSimulator(const MuJoCoSimulator &) = delete;
@@ -31,6 +36,12 @@ class MuJoCoSimulator {
     static MuJoCoSimulator simulator;
     return simulator;
   }
+
+  // Expected sensor names
+  constexpr static char NAME_GYRO[] = "gyro_sensor";
+  constexpr static char NAME_ACCEL[] = "accel_sensor";
+  constexpr static char NAME_ORIENT[] = "orient_sensor";
+
 
   // MuJoCo data structures
   mjModel *m = NULL;  // MuJoCo model
@@ -57,6 +68,11 @@ class MuJoCoSimulator {
   std::map<std::string, double> k_p;  // Proportional gain
   std::map<std::string, double> k_d;   // Derivative gain
   std::map<std::string, double> k_t;   // feedforward (torque) gain
+
+  // an array of doubles seemed better than using an opengl vector tuple
+  std::array<double, 4> sensor_orientation = {0.0, 0.0, 0.0, 0.0}; // Quaternion
+  std::array<double, 4> sensor_angular_vel = {0.0, 0.0, 0.0};
+  std::array<double, 4> sensor_linear_acc = {0.0, 0.0, 0.0};
 
   int freeflyer_nq;
 

--- a/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
+++ b/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
@@ -42,6 +42,9 @@ class MuJoCoSimulator {
     return simulator;
   }
 
+  // Expected sensor link name
+  constexpr static char NAME_SENSOR_LINK[] = "sensor_link";
+
   // Expected sensor names
   constexpr static char NAME_GYRO[] = "gyro_sensor";
   constexpr static char NAME_ACCEL[] = "accel_sensor";

--- a/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
+++ b/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
@@ -12,17 +12,22 @@
 #include <string>
 #include <vector>
 
+#include <sensor_msgs/msg/imu.hpp>
+
 namespace bolt_mujoco_simulation {
 
 class MuJoCoSimulator {
  private:
   MuJoCoSimulator();
   void syncStates();
+  void publishImuData();
 
-  // Sensor IDs and similar
-  int sensor_orient_id;
-  int sensor_angular_vel_id;
-  int sensor_linear_acc_id;
+  // Sensordata offsets and similar
+  int sensor_orient_offset;
+  int sensor_angular_vel_offset;
+  int sensor_linear_acc_offset;
+
+  std::shared_ptr<rclcpp::Publisher<sensor_msgs::msg::Imu>> sensor_imu_publisher;
 
  public:
   // Modern singleton approach

--- a/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
+++ b/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
@@ -76,8 +76,8 @@ class MuJoCoSimulator {
 
   // an array of doubles seemed better than using an opengl vector tuple
   std::array<double, 4> sensor_orientation = {0.0, 0.0, 0.0, 0.0}; // Quaternion
-  std::array<double, 4> sensor_angular_vel = {0.0, 0.0, 0.0};
-  std::array<double, 4> sensor_linear_acc = {0.0, 0.0, 0.0};
+  std::array<double, 3> sensor_angular_vel = {0.0, 0.0, 0.0};
+  std::array<double, 3> sensor_linear_acc = {0.0, 0.0, 0.0};
 
   int freeflyer_nq;
 

--- a/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
+++ b/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
@@ -43,7 +43,7 @@ class MuJoCoSimulator {
   }
 
   // Expected sensor link name
-  constexpr static char NAME_SENSOR_LINK[] = "sensor_link";
+  constexpr static char NAME_SENSOR_IMU_LINK[] = "imu_link";
 
   // Expected sensor names
   constexpr static char NAME_GYRO[] = "gyro_sensor";

--- a/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
+++ b/bolt_mujoco_simulation/include/bolt_mujoco_simulation/mujoco_simulator.hpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <random>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
 #include <vector>
@@ -21,6 +22,12 @@ class MuJoCoSimulator {
   MuJoCoSimulator();
   void syncStates();
   void publishImuData();
+  double computeNoise();
+
+  // "Noise Maker"
+  std::mt19937 random_engine;
+  std::normal_distribution<double> normal_dist;
+
 
   // Sensordata offsets and similar
   int sensor_orient_offset;
@@ -50,6 +57,8 @@ class MuJoCoSimulator {
   constexpr static char NAME_ACCEL[] = "accel_sensor";
   constexpr static char NAME_ORIENT[] = "orient_sensor";
 
+  // Enabling sensor noise
+  bool enable_noise = true;
 
   // MuJoCo data structures
   mjModel *m = NULL;  // MuJoCo model
@@ -114,6 +123,11 @@ class MuJoCoSimulator {
   // Scroll callback
   static void scrollCB(GLFWwindow *window, double xoffset, double yoffset);
   void scrollCBImpl(GLFWwindow *window, double xoffset, double yoffset);
+
+  // Fully sets random engine with new parameters,
+  // does NOT change enable_noise though!
+  // The noise will be from a normal distribution.
+  void setNoiseParams(double mean, double dev);
 
   // Non-blocking
   void read(std::map<std::string, double> &pos,

--- a/bolt_mujoco_simulation/package.xml
+++ b/bolt_mujoco_simulation/package.xml
@@ -12,6 +12,7 @@
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>sensor_msgs</depend>
   <depend>libglfw3-dev</depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/bolt_mujoco_simulation/src/mujoco_simulator.cpp
+++ b/bolt_mujoco_simulation/src/mujoco_simulator.cpp
@@ -357,7 +357,7 @@ void MuJoCoSimulator::syncStates() {
 void MuJoCoSimulator::publishImuData() {
   auto now = node->get_clock()->now();
   sensor_msgs::msg::Imu msg;
-  msg.header.frame_id = NAME_SENSOR_LINK;
+  msg.header.frame_id = NAME_SENSOR_IMU_LINK;
   msg.header.stamp.sec = now.seconds();
   msg.header.stamp.nanosec = now.nanoseconds();
 

--- a/bolt_mujoco_simulation/src/mujoco_simulator.cpp
+++ b/bolt_mujoco_simulation/src/mujoco_simulator.cpp
@@ -355,7 +355,12 @@ void MuJoCoSimulator::syncStates() {
 }
 
 void MuJoCoSimulator::publishImuData() {
-  auto msg = sensor_msgs::msg::Imu();
+  auto now = node->get_clock()->now();
+  sensor_msgs::msg::Imu msg;
+  msg.header.frame_id = NAME_SENSOR_LINK;
+  msg.header.stamp.sec = now.seconds();
+  msg.header.stamp.nanosec = now.nanoseconds();
+
   msg.angular_velocity.x = d->sensordata[sensor_angular_vel_offset];
   msg.angular_velocity.y = d->sensordata[sensor_angular_vel_offset + 1];
   msg.angular_velocity.z = d->sensordata[sensor_angular_vel_offset + 2];


### PR DESCRIPTION
Out of the required features, this currently implements a virtual imu sensor in the mujoco simulation, publishing its data onto a topic at 60Hz.

Features to be done still are:

URDF specifications for the real robot specifically
Noise
Contact Sensors